### PR TITLE
added dockerfile and dockercompose file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.23 as builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o main ./cmd/server
+RUN ls -l /app
+
+FROM alpine:latest
+WORKDIR /root/
+COPY --from=builder /app/main .
+RUN chmod +x main
+CMD ["./main"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+
+services:
+  app:
+    build: .
+    ports:
+      - "8080:8080"
+      - "9008:9008"
+      - "8081:8081"
+    environment:
+      - POSTGRES_DSN=postgres://user:password@db:5432/app?sslmode=disable
+    depends_on:
+      - db
+
+  db:
+    image: postgres:14
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: app
+    ports:
+      - "5432:5432"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/skip-mev/platform-take-home
 
-go 1.23.2
+go 1.22.7
+
+toolchain go1.22.10
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.23.0


### PR DESCRIPTION
added dockerfile and dockercompose file.

This PR solves the 3 main issues out of the [mentioned 6 issues.](https://github.com/skip-mev/platform-take-home?tab=readme-ov-file#exercise) I have prioritised them in the following order:

- **running the server locally is a bit of a pain, since it requires manually standing up a Postgres database** -- thought to solve this using a common stack featured by docker compose, where we mention the apps/databases being used, and dev would just need to do the docker-compose up?

- **the deployment process is manual and error-prone. Whenever a deployment happens, we suffer a tiny bit of downtime due to the server being down.** -- This can be solved using docker and then setting up a CI/CD pipeline to build, test, and deploy the Docker images automatically.. maybe we can extend this using k8s or ECS, taking further advantage of deployment strategies like canary/bluegreen/rolling update?

- **there's no easy way to share a feature update with our colleagues, since we only have a local and production environment.** -- We can think of implementing this via ArgoCD envs, as you mentioned that you use it.. so we either setup staging environment in argocd such that manifests first gets deployed to staging env, and seeing the outcome, we then decide whether to move ahead to prod.
